### PR TITLE
Switch to the user data dir in roaming.

### DIFF
--- a/src/main/java/io/goobox/sync/common/Utils.java
+++ b/src/main/java/io/goobox/sync/common/Utils.java
@@ -47,7 +47,7 @@ public class Utils {
     }
 
     public static Path getDataDir() {
-        return Paths.get(AppDirsFactory.getInstance().getUserDataDir(APP_NAME, null, ""));
+        return Paths.get(AppDirsFactory.getInstance().getUserDataDir(APP_NAME, null, "", true));
     }
 
     public static Path getSyncDir() {


### PR DESCRIPTION
Since, electron assumes user data are stored in `AppData\Roaming\Goobox` in Windows, backend apps should store user data in the same dir.