### PR TITLE
Support icon overlay in mac.

### DIFF
--- a/src/main/java/io/goobox/sync/common/overlay/OverlayIconProvider.java
+++ b/src/main/java/io/goobox/sync/common/overlay/OverlayIconProvider.java
@@ -19,7 +19,7 @@ package io.goobox.sync.common.overlay;
 import java.nio.file.Path;
 
 public interface OverlayIconProvider {
-    
+
     public OverlayIcon getIcon(Path path);
 
 }


### PR DESCRIPTION
From the readme of [liferay-nativity](https://github.com/liferay/liferay-nativity), we have to register icon files at runtime, which means the caller of `OverlayHelper` has to give paths to icon files. I hence update `OverlayIconProvider` interface and add `getIconFile` which returns an icon file path associated with the given `OverlayIcon` state.