### PR TITLE
Wait until the initialization finishes before refreshing icons

### DIFF
--- a/src/main/java/io/goobox/sync/common/overlay/OverlayHelper.java
+++ b/src/main/java/io/goobox/sync/common/overlay/OverlayHelper.java
@@ -121,6 +121,8 @@ public class OverlayHelper implements FileIconControlCallback, ContextMenuContro
                     logger.debug("Register {} with ID {} ({})", icon, String.valueOf(state.id()), state);
                     fileIconControl.registerIconWithId(
                             icon.toAbsolutePath().toString(), state.name(), String.valueOf(state.id()));
+                    // registerIconWithId needs to wait some seconds so that the FinderSyncExtension reads the previous
+                    // message and doesn't drop new one.
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException e) {


### PR DESCRIPTION
In my observations, `FileIconControl.refreshIcons` seems to has to be called after registering overlay icons in macOS, which means apps have to wait until the initialization finishes before refreshing icons.

This PR adds a Future instance so that `refresh` method can wait until the initialization finishes. 

`registerIconWithId` also needs to wait some second until the FinderSyncExtension reads the previous message. So, this PR add `Thread.sleep(1000)` for them, too.