### PR TITLE
Wait 10 more seconds before registering overlay icons

### DIFF
--- a/src/main/java/io/goobox/sync/common/overlay/OverlayHelper.java
+++ b/src/main/java/io/goobox/sync/common/overlay/OverlayHelper.java
@@ -113,8 +113,20 @@ public class OverlayHelper implements FileIconControlCallback, ContextMenuContro
         // Register icons
         if (OSDetector.isApple() || OSDetector.isLinux()) {
 
+            // The above `enableFileIcons` method returns immediately but it needs more time to initialize
+            // FinderSyncExtension.
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted while registering overlay icons: {}", e.getMessage());
+            }
+
             final Path resourceDir = Paths.get(System.getProperty("goobox.resource", "."));
             for (OverlayIcon state : OverlayIcon.values()) {
+
+                if (state == OverlayIcon.NONE) {
+                    continue;
+                }
 
                 final Path icon = resourceDir.resolve(String.format("overlay_%s.icns", state.name())).toAbsolutePath();
                 if (Files.exists(icon)) {


### PR DESCRIPTION
`enableFileIcons` method returns immediately but FinderSyncExtension needs more time to initialize it. How much time it takes is depended on the environment. So, I choose a random longer duration. (1 sec didn't work for me) 